### PR TITLE
Fix compilation with glibmm >= 2.49.1

### DIFF
--- a/src/TextWriter.cpp
+++ b/src/TextWriter.cpp
@@ -61,7 +61,7 @@ TextWriter::TextWriter(int in_x, int in_y, Renderer &in_renderer,
     fontname = STRING(fontname << " " << in_size);
     Pango::FontDescription* font_desc = new Pango::FontDescription(fontname);
     Glib::RefPtr<Pango::Font> ret = Gdk::GL::Font::use_pango_font(*font_desc, 0, 128, list_start);
-    if (ret == 0)
+    if (!ret)
       throw LinthesiaError("An error ocurred while trying to use use_pango_font() with "
                            "font '" + fontname + "'");
 


### PR DESCRIPTION
`RefPtr<T_CppObject>::operator bool()` has made explicit in
https://github.com/GNOME/glibmm/commit/aee3a6f.
Hence a 0-equivalence check for null will fail.

This change is a part of 29d7c84; the other part has been fixed by a0f09b3.