### PR TITLE
More robust font lookup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ AC_CHECK_HEADERS([string string.h iostream algorithm locale vector sstream queue
 PKG_CHECK_MODULES([GTKGLEXTMM],[gtkglextmm-1.2])
 PKG_CHECK_MODULES([GTKMM],[gtkmm-2.4])
 PKG_CHECK_MODULES([GCONFMM],[gconfmm-2.6])
+PKG_CHECK_MODULES([FONTCONFIG],[fontconfig])
 PKG_CHECK_MODULES([ALSA],[alsa])
 
 # Checks for typedefs, structures, and compiler characteristics.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,13 +58,13 @@ noinst_HEADERS +=		CompatibleSystem.h \
 				UserSettings.h \
 				Version.h
 
-linthesia_LDFLAGS = @GTKMM_LIBS@ @GCONFMM_LIBS@ @GTKGLEXTMM_LIBS@ @ALSA_LIBS@
+linthesia_LDFLAGS = @GTKMM_LIBS@ @GCONFMM_LIBS@ @GTKGLEXTMM_LIBS@ @FONTCONFIG_LIBS@ @ALSA_LIBS@
 linthesia_LDADD = libmidi.la
 linthesia_CXXFLAGS = -std=c++11 -iquote $(srcdir)/libmidi
-linthesia_CPPFLAGS = @GTKMM_CFLAGS@ @GCONFMM_CFLAGS@ @GTKGLEXTMM_CFLAGS@ @ALSA_CFLAGS@ -DGRAPHDIR="\"${graphdir}\"" -DSCRIPTDIR="\"${scriptdir}\""
+linthesia_CPPFLAGS = @GTKMM_CFLAGS@ @GCONFMM_CFLAGS@ @GTKGLEXTMM_CFLAGS@ @FONTCONFIG_CFLAGS@ @ALSA_CFLAGS@ -DGRAPHDIR="\"${graphdir}\"" -DSCRIPTDIR="\"${scriptdir}\""
 
 ctags-dependencies:
-	@$(CC) -M -std=c++11 -I/usr/include @GTKMM_CFLAGS@ @GCONFMM_CFLAGS@ @GTKGLEXTMM_CFLAGS@ @ALSA_CFLAGS@ \
+	@$(CC) -M -std=c++11 -I/usr/include @GTKMM_CFLAGS@ @GCONFMM_CFLAGS@ @GTKGLEXTMM_CFLAGS@ @FONTCONFIG_CFLAGS@ @ALSA_CFLAGS@ \
 		$(dist_libmidi_la_SOURCES) $(noinst_HEADERS) $(dist_linthesia_SOURCES) 2>/dev/null | \
 		sed 's/^.*://;s/^ //;s/ \\//;s/ /\n/g' | \
 		sort -u | \


### PR DESCRIPTION
Try to load fonts in Pango multiple times in order until finding a match.

It lets the program continue even if a bad font name is entered in the settings.
This order will be tried: (1) exact name requested (2) font in user settings (3) list of fallback fonts

By this method, I also eliminate the approximate lookup in the X font database to check if an entry is available or not.

probably related: #29

EDIT: +just a minor style edit