### PR TITLE
update build dependencies

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
     - name: update distro deps
       run: sudo apt-get update -y
     - name: install dependencies
-      run: sudo apt-get install -y libtool-bin build-essential meson ninja-build libgconf2-dev libasound2-dev libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libglibmm-2.4-dev
+      run: sudo apt-get install -y libtool-bin build-essential meson ninja-build libasound2-dev libsqlite3-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libglibmm-2.4-dev
     - name: configure
       run: meson build
     - name: build

--- a/BUILD-DEPENDS
+++ b/BUILD-DEPENDS
@@ -1,6 +1,6 @@
-libgconf2-dev
 libasound2-dev
 libsqlite3-dev
 libsdl2-dev
 libsdl2-ttf-dev
 libsdl2-image-dev
+libglibmm-2.4-dev

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: linthesia
 Section: games
 Priority: extra
 Maintainer: Cleto Martin Angelina <cleto.martin@gmail.com>
-Build-Depends: debhelper (>= 7), libgtkmm-2.4-dev, libgconf2-dev,
+Build-Depends: debhelper (>= 7), libgtkmm-2.4-dev, libglibmm-2.4-dev,
  libgtkglextmm-x11-1.2-dev, libasound2-dev, docbook-xsl, xsltproc, 
 Standards-Version: 3.8.3
 Homepage: https://sourceforge.net/projects/linthesia/


### PR DESCRIPTION
libgconf2-dev is no longer a dependency and
added libglibmm-2.4-dev to BUILD-DEPENDS