### PR TITLE
Show text events

### DIFF
--- a/src/PlayingState.cpp
+++ b/src/PlayingState.cpp
@@ -762,6 +762,10 @@ void PlayingState::Draw(Renderer &renderer) const {
   TextWriter time_text(Layout::ScreenMarginX + 39, text_y+2, renderer, false, Layout::TimeFontSize);
   time_text << STRING(current_time << " / " << total_time << percent_complete);
 
+  for (int i = 0; i < m_state.midi->Tracks().size(); i++) {
+    time_text << " " << m_state.midi->Tracks()[i].LastText();
+  }
+
   // Draw a song progress bar along the top of the screen
   const int time_pb_width = static_cast<int>(m_state.midi->GetSongPercentageComplete() * (GetStateWidth() -
                                                                                           Layout::ScreenMarginX*2));

--- a/src/libmidi/MidiTrack.h
+++ b/src/libmidi/MidiTrack.h
@@ -69,6 +69,11 @@ public:
     return m_note_set;
   }
 
+  const std::string LastText() const
+  {
+    return m_last_event == -1 ? "" : m_events[m_last_event].Text();
+  }
+
   void SetTrackId(size_t track_id);
 
   // Reports whether this track contains any Note-On MIDI events


### PR DESCRIPTION
Basic implementation.

Show text ahead of time to preview it, and color current text played, can help to visualize better.

That would need a list widget or textarea.

This can be used for lessons or info text

fixes #16 