### PR TITLE
fix: text looks garbled with SDL2_ttf 2.0.18

### DIFF
--- a/src/TextWriter.cpp
+++ b/src/TextWriter.cpp
@@ -82,7 +82,10 @@ void Text::DrawText(TextWriter& tw, SDL_Color color, int draw_x, int draw_y) con
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, sFont->w, sFont->h, 0, GL_BGRA, GL_UNSIGNED_BYTE, sFont->pixels);
+
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, sFont->pitch / sFont->format->BytesPerPixel);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, sFont->w, sFont->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, sFont->pixels);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
   glPushMatrix();
 


### PR DESCRIPTION
the surfaces returned from 2.0.18 seem to have a higher
pitch than the width of the surface, and the code was
not prepared to deal with this, so the text appeared garbled

GL_UNPACK_ROW_LENGTH is set with the pitch of the rendered
surface, this allows the text to be rendered correctly

closes #65