### PR TITLE
fix desync issues when moving before the beginning

### DIFF
--- a/src/libmidi/Midi.cpp
+++ b/src/libmidi/Midi.cpp
@@ -352,11 +352,11 @@ microseconds_t Midi::GetEventPulseInMicroseconds(unsigned long event_pulses,
 void Midi::Reset(microseconds_t lead_in_microseconds, microseconds_t lead_out_microseconds) {
   m_microsecond_lead_in = lead_in_microseconds;
   m_microsecond_lead_out = lead_out_microseconds;
-  m_microsecond_song_position = m_microsecond_dead_start_air - lead_in_microseconds;
+  m_microsecond_song_position = GetSongInitialPositionInMicroseconds();
   m_first_update_after_reset = true;
 
   for (MidiTrackList::iterator i = m_tracks.begin(); i != m_tracks.end(); ++i) {
-    i->Reset();
+    i->GoTo(m_microsecond_song_position);
   }
 }
 
@@ -380,22 +380,14 @@ MidiEventListWithTrackId Midi::Update(microseconds_t delta_microseconds) {
   if (!m_initialized)
     return aggregated_events;
 
-  // Move everything forward (fallen keys, the screen keyboard)
-  // These variable is used on redraw later
-  m_microsecond_song_position += delta_microseconds;
-  if (m_first_update_after_reset) {
-    delta_microseconds += m_microsecond_song_position;
-    m_first_update_after_reset = false;
-  }
-
   if (delta_microseconds == 0)
     return aggregated_events;
 
-  if (m_microsecond_song_position < 0)
-    return aggregated_events;
+  // Move everything forward (fallen keys, the screen keyboard)
+  // These variable is used on redraw later
+  m_microsecond_song_position += delta_microseconds;
 
-  if (delta_microseconds > m_microsecond_song_position)
-    delta_microseconds = m_microsecond_song_position;
+
 
   const size_t track_count = m_tracks.size();
   // These code is not related to fallen keys
@@ -425,6 +417,8 @@ void Midi::GoTo(microseconds_t microsecond_song_position) {
 //    Reset(m_microsecond_lead_in, m_microsecond_lead_out);
 //    return;
 //}
+  microsecond_song_position = max(GetSongInitialPositionInMicroseconds(), microsecond_song_position);
+
 
   m_microsecond_song_position = microsecond_song_position;
 

--- a/src/libmidi/Midi.h
+++ b/src/libmidi/Midi.h
@@ -51,6 +51,11 @@ public:
     return m_microsecond_song_position;
   }
 
+  microseconds_t GetSongInitialPositionInMicroseconds() const {
+    return m_microsecond_dead_start_air - m_microsecond_lead_in;
+  }
+
+
   microseconds_t GetSongLengthInMicroseconds() const;
 
   microseconds_t GetDeadAirStartOffsetMicroseconds() const {


### PR DESCRIPTION
capped the GoTo method to the starting position of the music

On reset, the individual midi tracks were set to the 0 position but the midi itself had a negative time (for the lead in). There were some tricks in the Update method to work around this, which otherwise would cause the tracks to start playing at the wrong time. These workarounds were removed and reset method of the Midi also sets the tracks to the same negative time. Both times should now always be in sync

closes #73