### PR TITLE
Fix g++12 warnings

### DIFF
--- a/src/EnumTile.h
+++ b/src/EnumTile.h
@@ -76,17 +76,16 @@ private:
   int m_x;
   int m_y;
 
-  Tga *m_button_graphics;
-  Tga *m_frame_graphics;
-
   EnumValue& m_value;
 
+  std::string m_tile_title;
+
+  Tga *m_button_graphics;
+  Tga *m_frame_graphics;
 
   ButtonState whole_tile;
   ButtonState button_mode_left;
   ButtonState button_mode_right;
-
-  std::string m_tile_title;
 
   int LookupGraphic(TrackTileGraphic graphic, bool button_hovering) const;
 };

--- a/src/EnumTile.h
+++ b/src/EnumTile.h
@@ -28,6 +28,8 @@ public:
   virtual void previous() = 0;
 
   virtual std::string AsText() const = 0;
+
+  virtual ~EnumValue() = default;
 };
 
 

--- a/src/FileSelector.cpp
+++ b/src/FileSelector.cpp
@@ -29,7 +29,7 @@ namespace FileSelector {
     exts.insert(".mid");
     exts.insert(".midi");
     for (set<string>::const_iterator i = exts.begin(); i != exts.end(); i++) {
-      int len = i->length();
+      size_t len = i->length();
       if (lower.length() > len && lower.substr(lower.length() - len, len) == *i)
         lower = lower.substr(0, lower.length() - len);
     }

--- a/src/FrameAverage.cpp
+++ b/src/FrameAverage.cpp
@@ -27,7 +27,7 @@ FrameAverage::FrameAverage(int n) :
  * 
  * @param[in] delta_us frame time in microseconds
  */
-void FrameAverage::Frame(unsigned long delta_us) {
+void FrameAverage::Frame(long delta_us) {
 
   if (delta_us < 0)
     return;

--- a/src/FrameAverage.h
+++ b/src/FrameAverage.h
@@ -35,8 +35,8 @@ public:
   unsigned long GetAverage();
 
 private:
-  vector<unsigned long> durations;
   unsigned long sum;
+  vector<unsigned long> durations;
   int pos;
 };
 

--- a/src/FrameAverage.h
+++ b/src/FrameAverage.h
@@ -26,7 +26,7 @@ public:
    * 
    * @param[in] delta_us frame time in microseconds
    */
-  void Frame(unsigned long delta_us);
+  void Frame(long delta_us);
 
   /**
    * returns the average time of the last frames

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -240,7 +240,7 @@ void GameStateManager::Update(bool skip_this_update) {
 
   // Manager's timer grows constantly
   const unsigned long now = Compatible::GetMicroseconds();
-  const unsigned long delta = now - m_last_microseconds;
+  const long delta = now - m_last_microseconds;
   m_last_microseconds = now;
   // Now that we've updated the time, we can return if
   // we've been told to skip this one.

--- a/src/MidiComm.h
+++ b/src/MidiComm.h
@@ -90,12 +90,14 @@ public:
   void Reset();
 
   void Reconnect();
+  bool ShouldReconnect() const;
 
 private:
   void Release();
 
   MidiCommDescription m_description;
   std::vector<std::pair<int,int> > notes_on;
+  bool m_should_reconnect = false;
 
 };
 

--- a/src/PlayingState.cpp
+++ b/src/PlayingState.cpp
@@ -249,10 +249,21 @@ void PlayingState::Listen() {
   while (m_state.midi_in->KeepReading()) {
 
     microseconds_t cur_time = m_state.midi->GetSongPositionInMicroseconds();
-    MidiEvent ev = m_state.midi_in->Read();
+    MidiEvent ev;
+    try {
+      ev = m_state.midi_in->Read();
+    } catch (const MidiError& ex) {
+      ex.GetErrorDescription();
+      ///TODO display device disconnected
+    }
+
     if (m_state.midi_in->ShouldReconnect())
     {
         m_state.midi_in->Reconnect();
+        continue;
+    }
+    if (m_state.midi_out->ShouldReconnect())
+    {
         m_state.midi_out->Reconnect();
         continue;
     }

--- a/src/PlayingState.cpp
+++ b/src/PlayingState.cpp
@@ -769,7 +769,7 @@ void PlayingState::Draw(Renderer &renderer) const {
   TextWriter time_text(Layout::ScreenMarginX + 39, text_y+2, renderer, false, Layout::TimeFontSize);
   time_text << STRING(current_time << " / " << total_time << percent_complete);
 
-  for (int i = 0; i < m_state.midi->Tracks().size(); i++) {
+  for (unsigned i = 0; i < m_state.midi->Tracks().size(); i++) {
     time_text << " " << m_state.midi->Tracks()[i].LastText();
   }
 

--- a/src/PlayingState.h
+++ b/src/PlayingState.h
@@ -95,6 +95,11 @@ private:
   ActiveNoteSet m_active_notes;
 
   bool m_first_update;
+  
+  // For retries
+  bool m_should_retry;
+  bool m_should_wait_after_retry;
+  microseconds_t m_retry_start;
 
   SharedState m_state;
   int m_current_combo;
@@ -104,11 +109,6 @@ private:
 
   // For octave sliding
   int m_note_offset;
-
-  // For retries
-  bool m_should_retry;
-  bool m_should_wait_after_retry;
-  microseconds_t m_retry_start;
 
   void eraseUntilTime(microseconds_t time);
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -49,6 +49,7 @@ SDL_Color Renderer::ToColor(int r, int g, int b, int a) {
 }
 
 void Renderer::SetVSyncInterval(int interval) {
+  std::cout << "Vsync interval: " << interval << std::endl;
 // #ifdef WIN32
 
 //    const char *extensions = reinterpret_cast<const char*>(static_cast<const unsigned char*>(glGetString( GL_EXTENSIONS )));

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -13,7 +13,7 @@
 #include "Tga.h"
 #include "SDL.h"
 
-static bool m_vsync_initialized;
+// static bool m_vsync_initialized;
 
 class Renderer {
 public:

--- a/src/SongLibState.cpp
+++ b/src/SongLibState.cpp
@@ -29,7 +29,7 @@ void SongLibState::Init() {
     m_current_path = UserSetting::Get(SONG_LIB_DIR_SETTINGS_KEY, MUSICDIR);
     // since it is unconfortable to crash when no file is present, let's test it now
     struct stat st;
-    if ( (!stat(m_current_path.c_str(),&st) == 0) || (! st.st_mode & S_IFDIR != 0) ) {
+    if ( (!stat(m_current_path.c_str(),&st) == 0) || !((st.st_mode & S_IFDIR) != 0) ) {
 	    m_current_path = m_base_path;
     }
 

--- a/src/SongLibState.cpp
+++ b/src/SongLibState.cpp
@@ -173,7 +173,7 @@ void SongLibState::UpdateSongTilesPage() {
     m_columns = slim ? 1 : max_columns;
 
     int rows = (GetStateHeight() - initial_y - Layout::ScreenMarginY) / each_y;
-    int tiles_per_page = rows * m_columns;
+    unsigned tiles_per_page = rows * m_columns;
     
     std::vector<SongTile>::size_type tiles_total = m_song_tiles.size();
     m_page_count = (tiles_per_page == 0 ? 0 : (tiles_total / tiles_per_page)) + 1;

--- a/src/SongTile.h
+++ b/src/SongTile.h
@@ -70,12 +70,12 @@ private:
   int m_x;
   int m_y;
 
-  bool m_dir;
-  bool m_visible;
-
   string m_path;
   string m_name;
   string m_current_path;
+
+  bool m_dir;
+  bool m_visible;
 
   Tga *m_frame_graphics;
 

--- a/src/StringUtil.h
+++ b/src/StringUtil.h
@@ -29,16 +29,18 @@ const string_type StringLower(string_type s) {
 
   std::locale loc;
   
-  std::transform(s.begin(), s.end(), s.begin(),
-		 std::bind1st( std::mem_fun( &std::ctype<typename string_type::value_type>::tolower ),
-			       &std::use_facet< std::ctype<typename string_type::value_type> >( loc ) ) );
+  using charType = typename std::remove_cv<typename std::remove_reference<string_type>::type>::type::value_type;
+  std::transform(s.begin(), s.end(), s.begin(), [&loc] (charType c) -> charType {
+    auto &facet = std::use_facet<std::ctype<charType>>(loc);
+    return facet.tolower(c);
+  });
   
   return s;
 }
 
 // E here is usually wchar_t
 template<class E, class T = std::char_traits<E>, class A = std::allocator<E> >
-class Widen : public std::unary_function< const std::string&, std::basic_string<E, T, A> > {
+class Widen{
 
 public:
   

--- a/src/TitleState.h
+++ b/src/TitleState.h
@@ -60,8 +60,8 @@ private:
   DeviceTile *m_output_tile;
   DeviceTile *m_input_tile;
 
-  EnumTile *m_keyboard_size_tile;
   StringTile *m_file_tile;
+  EnumTile *m_keyboard_size_tile;
 
   bool m_skip_next_mouse_up;
 };

--- a/src/TrackTile.cpp
+++ b/src/TrackTile.cpp
@@ -137,7 +137,7 @@ void TrackTile::Draw(Renderer &renderer, const Midi *midi, Tga *buttons, Tga *bo
   TextWriter instrument(95, 14, renderer, false, 14);
   instrument << track.InstrumentName();
   TextWriter note_count(95, 35, renderer, false, 14);
-  note_count << static_cast<const unsigned int>(track.Notes().size());
+  note_count << track.Notes().size();
 
   int color_offset = GraphicHeight * static_cast<int>(m_color);
   if (gray_out_buttons)

--- a/src/libmidi/MidiUtil.h
+++ b/src/libmidi/MidiUtil.h
@@ -75,6 +75,8 @@ enum MidiErrorCode {
 class MidiError : public std::exception {
 public:
    MidiError(MidiErrorCode error) : m_error(error) { }
+   MidiError(const MidiError& error) = default;
+   
    std::string GetErrorDescription() const;
 
    const MidiErrorCode m_error;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,7 @@ public:
     m_sdl_window(sdl_window)
   {
   }
+  virtual ~DrawingArea() = default;
 
   bool GameLoop();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,9 +242,9 @@ int keyToNote(SDL_KeyboardEvent& event) {
   case SDL_SCANCODE_LEFTBRACKET:  return 12*(oct+1) + 9;  /* A  */
   case SDL_SCANCODE_EQUALS:       return 12*(oct+1) + 10; /* A# */
   case SDL_SCANCODE_RIGHTBRACKET: return 12*(oct+1) + 11; /* B  */
-  }
 
-  return -1;
+  default: return -1;
+  }
 }
 
 typedef set<int> ConnectMap;
@@ -414,7 +414,7 @@ void show_help() {
      << "\t" << "--min-key" << " " << _("to define min key") << endl
      << "\t" << "--max-key" << " " << _("to define max key") << endl
      << "\t" << "--lib-path" << " " << _("to define directory for music library") << endl
-     << "\t" << "--reset-lib-path" << " " << _("reset directory for music library to "MUSICDIR) << endl
+     << "\t" << "--reset-lib-path" << " " << _("reset directory for music library to " MUSICDIR) << endl
      << "\t" << "-h, --help" << " " << _("show this help") << endl
      << "\t" << "-v, --version" << " " << _("show linthesia version") << endl
      << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,8 +109,8 @@ public:
 
   virtual void on_configure_event();
 protected:
-  virtual void on_expose_event(SDL_WindowEvent& event);
-  virtual void on_hide_event(SDL_WindowEvent& event);
+  virtual void on_expose_event();
+  virtual void on_hide_event();
 
   virtual bool on_motion_notify(SDL_MouseMotionEvent& event);
   virtual bool on_button_press(SDL_MouseButtonEvent& event);
@@ -169,10 +169,10 @@ void DrawingArea::on_window_event(SDL_WindowEvent& event)
   switch (event.event)
   {
     case SDL_WINDOWEVENT_EXPOSED:
-      on_expose_event(event);
+      on_expose_event();
       break;
     case SDL_WINDOWEVENT_HIDDEN:
-      on_hide_event(event);
+      on_hide_event();
       break;
     case SDL_WINDOWEVENT_RESIZED:
     case SDL_WINDOWEVENT_SIZE_CHANGED:
@@ -353,12 +353,12 @@ void DrawingArea::on_configure_event() {
   glEnd();
 }
 
-void DrawingArea::on_expose_event(SDL_WindowEvent& event) {
+void DrawingArea::on_expose_event() {
   if (!window_state.IsActive())
     window_state.Activate();
 }
 
-void DrawingArea::on_hide_event(SDL_WindowEvent& event) {
+void DrawingArea::on_hide_event() {
   if (window_state.IsActive())
     window_state.Deactivate();
 }
@@ -370,7 +370,7 @@ bool DrawingArea::GameLoop() {
     state_manager->Update(window_state.JustActivated());
 
     Renderer rend(m_sdl_window);
-    rend.SetVSyncInterval(vsync_interval);
+    // rend.SetVSyncInterval(vsync_interval);
 
     state_manager->Draw(rend);
   }
@@ -420,7 +420,7 @@ void show_help() {
      << endl;
 }
 
-bool has_invalid_options(int argc, char *argv[]) {
+bool has_invalid_options(char *argv[]) {
   for (char **pargv = argv; *pargv != NULL; pargv++) {
     char i = *pargv[0];
     char* j = *pargv+1;
@@ -456,7 +456,7 @@ int main(int argc, char *argv[]) {
     UserSetting::Initialize();
 
     int show_help_exit_status = 0;
-    bool invalid_options = has_invalid_options(argc, argv);
+    bool invalid_options = has_invalid_options(argv);
     if (invalid_options) {
       show_help_exit_status = 1;
     }


### PR DESCRIPTION
Fix warnings while compiling with g++12

- Initilization order (reorder warnings)
- Implicity copy constructor
- Missing virtual destructor
- Type comparison warnings
- Precedent warning
- Unused variable warnings
- Deprecated warnings

There are a few bug fixes, in the `void Frame(unsigned long delta_us)` method
https://github.com/linthesia/linthesia/blob/1f2701241f8865c2f5c14a97b81ae64884cf0396/src/FrameAverage.cpp#L32
delta_us is unsiged so it can never be less than 0.

Also here in the `SongLibState::Init` the `!=` is evaluated first so thats not really checking if is a directory or not
https://github.com/linthesia/linthesia/blob/1f2701241f8865c2f5c14a97b81ae64884cf0396/src/SongLibState.cpp#L32